### PR TITLE
feature: Exception raising reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,33 +221,8 @@ Use the `LoggingOptions` class if you want to log the profiling results to a fil
 - `duration_threshold`: A float valued property which determines the threshold for the no. of seconds
    a line of code can spend executing before it is logged. The default is 0.0.
 
-
 Logging is compatible with the standard Python logging library and its [Django extension](https://docs.djangoproject.com/en/5.0/topics/logging/).
 For example, to have **queryhunter** log to a file called `queryhunter.log`, we can add the following to our `settings.py` file:
-
-
-### RaisingOptions
-
-Use the `RaisingOptions` class if you want *queryhunter* to raise an exception when a bad query is found. `RaisingOptions` class can be configured via the attributes below:
-
-- `sort_by`: A string valued property which determines the order in which each line of code is printed
-   for each module profiled. Options are `line_no, -line_no, count, -count, duration, -duration`.
-   The default is `line_no`.
-- `modules`: An optional list of strings which can be used to filter the modules which are profiled. 
-   The default is `None`, which means all modules touched within the context are profiled.
-- `max_sql_length`: An optional integer valued property which determines the maximum length of the SQL query printed.
-   The default is None, meaning the entire SQL query is printed.
-- `count_highlighting_threshold`: An integer valued property which determines the threshold for the number of 
-   queries executed on a line of code before it is highlighted red in the output. The default is 5.
-- `duration_highlighting_threshold`: A float valued property which determines the threshold for the no. of seconds
-   a line of code can spend executing before it is highlighted red in the output. The default is 0.1.
-- `count_threshold`: An integer valued property which determines the threshold for the number of 
-   queries executed on a line of code before it is printed. The default is 1.
-- `duration_threshold`: A float valued property which determines the threshold for the no. of seconds
-   a line of code can spend executing before it is printed. The default is 0.0.
-
-> [!WARNING]
-> Setting `RaisingOptions` can be quite useful for testing, since it causes tests with slow/repeating queries to fail. *You should not use `RaisingOptions` in production.*
 
 ```python
 QUERYHUNTER_REPORTING_OPTIONS = LoggingOptions(logger_name='queryhunter', sort_by='-count')
@@ -285,6 +260,30 @@ This will produce a log file `queryhunter.log` which has content like below:
 2024-02-18 07:04:16,182 - Module: django-queryhunter/queryhunter/tests/my_module.py | Line no: 14 | Code: authors.append(post.author.name) | Num. Queries: 5 | SQL: SELECT "tests_author"."id", "tests_author"."name" FROM "tests_author" WHERE "tests_author"."id" = %s LIMIT 21 | Duration: 3.174999999999706e-05 | url: /authors/ | method: GET
 2024-02-18 07:04:16,182 - Module: django-queryhunter/queryhunter/tests/my_module.py | Line no: 13 | Code: for post in posts: | Num. Queries: 1 | SQL: SELECT "tests_post"."id", "tests_post"."content", "tests_post"."author_id" FROM "tests_post" | Duration: 1.2500000000026379e-05 | url: /authors/ | method: GET
 ```
+
+
+### RaisingOptions
+
+Use the `RaisingOptions` class if you want *queryhunter* to raise an exception when a bad query is found. `RaisingOptions` class can be configured via the attributes below:
+
+- `sort_by`: A string valued property which determines the order in which each line of code is printed
+   for each module profiled. Options are `line_no, -line_no, count, -count, duration, -duration`.
+   The default is `line_no`.
+- `modules`: An optional list of strings which can be used to filter the modules which are profiled. 
+   The default is `None`, which means all modules touched within the context are profiled.
+- `max_sql_length`: An optional integer valued property which determines the maximum length of the SQL query printed.
+   The default is None, meaning the entire SQL query is printed.
+- `count_highlighting_threshold`: An integer valued property which determines the threshold for the number of 
+   queries executed on a line of code before it is highlighted red in the output. The default is 5.
+- `duration_highlighting_threshold`: A float valued property which determines the threshold for the no. of seconds
+   a line of code can spend executing before it is highlighted red in the output. The default is 0.1.
+- `count_threshold`: An integer valued property which determines the threshold for the number of 
+   queries executed on a line of code before it is printed. The default is 1.
+- `duration_threshold`: A float valued property which determines the threshold for the no. of seconds
+   a line of code can spend executing before it is printed. The default is 0.0.
+
+> [!WARNING]
+> Setting `RaisingOptions` can be quite useful for testing, since it causes tests with slow/repeating queries to fail. *You should not use `RaisingOptions` in production.*
 
 
 ## Custom Metadata

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Use the `RaisingOptions` class if you want *queryhunter* to raise an exception w
 - `duration_threshold`: A float valued property which determines the threshold for the no. of seconds
    a line of code can spend executing before it is printed. The default is 0.0.
 
-> [!INFO]
+> [!WARNING]
 > Setting `RaisingOptions` can be quite useful for testing, since it causes tests with slow/repeating queries to fail. *You should not use `RaisingOptions` in production.*
 
 ```python

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Use the `LoggingOptions` class if you want to log the profiling results to a fil
 - `duration_threshold`: A float valued property which determines the threshold for the no. of seconds
    a line of code can spend executing before it is logged. The default is 0.0.
 
+
 Logging is compatible with the standard Python logging library and its [Django extension](https://docs.djangoproject.com/en/5.0/topics/logging/).
 For example, to have **queryhunter** log to a file called `queryhunter.log`, we can add the following to our `settings.py` file:
 

--- a/README.md
+++ b/README.md
@@ -274,14 +274,10 @@ Use the `RaisingOptions` class if you want *queryhunter* to raise an exception w
    The default is `None`, which means all modules touched within the context are profiled.
 - `max_sql_length`: An optional integer valued property which determines the maximum length of the SQL query printed.
    The default is None, meaning the entire SQL query is printed.
-- `count_highlighting_threshold`: An integer valued property which determines the threshold for the number of 
-   queries executed on a line of code before it is highlighted red in the output. The default is 5.
-- `duration_highlighting_threshold`: A float valued property which determines the threshold for the no. of seconds
-   a line of code can spend executing before it is highlighted red in the output. The default is 0.1.
 - `count_threshold`: An integer valued property which determines the threshold for the number of 
-   queries executed on a line of code before it is printed. The default is 1.
+   queries executed on a line of code before an exception is raised. The default is 1.
 - `duration_threshold`: A float valued property which determines the threshold for the no. of seconds
-   a line of code can spend executing before it is printed. The default is 0.0.
+   a line of code can spend executing before an exception is raised. The default is 0.5.
 
 > [!WARNING]
 > Setting `RaisingOptions` can be quite useful for testing, since it causes tests with slow/repeating queries to fail. *You should not use `RaisingOptions` in production.*

--- a/README.md
+++ b/README.md
@@ -225,6 +225,30 @@ Use the `LoggingOptions` class if you want to log the profiling results to a fil
 Logging is compatible with the standard Python logging library and its [Django extension](https://docs.djangoproject.com/en/5.0/topics/logging/).
 For example, to have **queryhunter** log to a file called `queryhunter.log`, we can add the following to our `settings.py` file:
 
+
+### RaisingOptions
+
+Use the `RaisingOptions` class if you want *queryhunter* to raise an exception when a bad query is found. `RaisingOptions` class can be configured via the attributes below:
+
+- `sort_by`: A string valued property which determines the order in which each line of code is printed
+   for each module profiled. Options are `line_no, -line_no, count, -count, duration, -duration`.
+   The default is `line_no`.
+- `modules`: An optional list of strings which can be used to filter the modules which are profiled. 
+   The default is `None`, which means all modules touched within the context are profiled.
+- `max_sql_length`: An optional integer valued property which determines the maximum length of the SQL query printed.
+   The default is None, meaning the entire SQL query is printed.
+- `count_highlighting_threshold`: An integer valued property which determines the threshold for the number of 
+   queries executed on a line of code before it is highlighted red in the output. The default is 5.
+- `duration_highlighting_threshold`: A float valued property which determines the threshold for the no. of seconds
+   a line of code can spend executing before it is highlighted red in the output. The default is 0.1.
+- `count_threshold`: An integer valued property which determines the threshold for the number of 
+   queries executed on a line of code before it is printed. The default is 1.
+- `duration_threshold`: A float valued property which determines the threshold for the no. of seconds
+   a line of code can spend executing before it is printed. The default is 0.0.
+
+> [!INFO]
+> Setting `RaisingOptions` can be quite useful for testing, since it causes tests with slow/repeating queries to fail. *You should not use `RaisingOptions` in production.*
+
 ```python
 QUERYHUNTER_REPORTING_OPTIONS = LoggingOptions(logger_name='queryhunter', sort_by='-count')
 

--- a/queryhunter/__init__.py
+++ b/queryhunter/__init__.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 from .context_manager import queryhunter
 from .reporting import (
-    ReportingOptions,
     LoggingOptions,
     PrintingOptions,
+    QueryHunterException,
+    RaisingOptions,
+    ReportingOptions,
 )
 
 
@@ -12,3 +14,12 @@ def default_base_dir(file) -> str:
     return str(Path(file).resolve().parent.parent)
 
 
+__all__ = [
+    "queryhunter",
+    "LoggingOptions",
+    "PrintingOptions",
+    "RaisingOptions",
+    "ReportingOptions",
+    "QueryHunterException",
+    "default_base_dir",
+]

--- a/queryhunter/context_manager.py
+++ b/queryhunter/context_manager.py
@@ -31,5 +31,9 @@ class queryhunter(contextlib.ContextDecorator):
         return self
 
     def __exit__(self, *exc):
-        self.reporter.report()
-        self._pre_execute_hook.__exit__(*exc)
+        try:
+            self.reporter.report()
+        finally:
+            # Ensure that we always call the exit hook, even if the `reporter.report` call raises an
+            # exception.
+            self._pre_execute_hook.__exit__(*exc)

--- a/queryhunter/reporting.py
+++ b/queryhunter/reporting.py
@@ -35,8 +35,8 @@ class LoggingOptions(ReportingOptions):
 
 @dataclass
 class RaisingOptions(ReportingOptions):
-    count_highlighting_threshold: int = 5
-    duration_highlighting_threshold: float = 0.5
+    count_threshold: int = 5
+    duration_threshold: float = 0.5
 
 
 class QueryHunterException(Exception):
@@ -99,7 +99,7 @@ class RaisingQueryHunterReporter(QueryHunterReporter):
             for line in module.lines:
                 if line.duration < self.options.duration_threshold or line.count < self.options.count_threshold:
                     continue
-                if line.duration >= self.options.duration_highlighting_threshold:
+                if line.duration >= self.options.duration_threshold:
                     raise QueryHunterException(f'Excessive time spent in module: {name} | {line}')
-                elif line.count >= self.options.count_highlighting_threshold:
+                elif line.count >= self.options.count_threshold:
                     raise QueryHunterException(f'Excessive repeated queries in module: {name} | {line}')

--- a/queryhunter/tests/tests.py
+++ b/queryhunter/tests/tests.py
@@ -3,7 +3,7 @@ import pytest
 from django.urls import reverse
 
 from queryhunter import queryhunter
-from queryhunter.reporting import PrintingOptions, LoggingOptions
+from queryhunter.reporting import PrintingOptions, LoggingOptions, QueryHunterException, RaisingOptions
 from queryhunter.tests.my_module import get_authors, create_posts
 
 
@@ -104,3 +104,13 @@ def test_logging():
     assert first_line.line_no == 13
     assert first_line.count == 1
     assert first_line.duration > 0
+
+@pytest.mark.django_db(transaction=True)
+def test_raising():
+    create_posts()
+    with queryhunter(reporting_options=RaisingOptions()):
+        try:
+            get_authors()
+            assert False, "queryhunter should have raised an exception"
+        except Exception as e:
+            assert isinstance(e, QueryHunterException)


### PR DESCRIPTION
This PR adds a new `RaisingQueryHunterReporter` report type. This reporter raises an exception when a bad query is found. Raising an exception is quite helpful while testing, since the offending query will cause the test to fail.